### PR TITLE
Use testodrome role for the new projects

### DIFF
--- a/internal/neonapi/client_test.go
+++ b/internal/neonapi/client_test.go
@@ -13,7 +13,7 @@ func testClient(t *testing.T) *Client {
 	if apiKey == "" {
 		t.Skip("NEON_API_KEY is not set")
 	}
-	return NewClient("stage.neon.tech", apiKey)
+	return NewClient("console-stage.neon.build", apiKey)
 }
 
 // Run with `export $(cat .env | xargs) && go test ./... -v -run TestCreateProject`
@@ -23,8 +23,11 @@ func TestCreateProject(t *testing.T) {
 
 	client := testClient(t)
 	prep, err := client.CreateProject(&CreateProject{
-		Name:     "test-project-1",
-		RegionID: "aws-eu-west-1",
+		Name:        "test-project-1",
+		RegionID:    "aws-eu-west-1",
+		Branch:      CreateProjectBranch{RoleName: "testodrome"},
+		PgVersion:   16,
+		Provisioner: "k8s-neonvm",
 	})
 	if err != nil {
 		t.Fatal(err)
@@ -32,6 +35,12 @@ func TestCreateProject(t *testing.T) {
 	resp, result, err := prep.Do(ctx)
 	if err != nil {
 		t.Fatal(err)
+	}
+	if len(resp.Roles) != 1 {
+		t.Fatalf("Expected 1 role, got %d", len(resp.Roles))
+	}
+	if resp.Roles[0].Name != "testodrome" {
+		t.Fatalf("Expected role name 'testodrome', got %s", resp.Roles[0].Name)
 	}
 
 	t.Logf("Project ID: %s", resp.Project.ID)

--- a/internal/neonapi/models.go
+++ b/internal/neonapi/models.go
@@ -130,11 +130,16 @@ type Endpoint struct {
 }
 
 type CreateProject struct {
-	Name     string `json:"name"`
-	RegionID string `json:"region_id"`
+	Name     string              `json:"name"`
+	RegionID string              `json:"region_id"`
+	Branch   CreateProjectBranch `json:"branch"`
 
 	PgVersion   int    `json:"pg_version"`
 	Provisioner string `json:"provisioner"`
+}
+
+type CreateProjectBranch struct {
+	RoleName string `json:"role_name"`
 }
 
 type DeleteProjectResponse struct {

--- a/internal/rules/create_project.go
+++ b/internal/rules/create_project.go
@@ -148,6 +148,7 @@ func (c *CreateProject) createProject(ctx context.Context, region models.Region)
 
 	createRequest := &neonapi.CreateProject{
 		Name:        fmt.Sprintf("test@%s-%d", c.config.Exitnode, projectSeqID),
+		Branch:      neonapi.CreateProjectBranch{RoleName: "testodrome"},
 		RegionID:    region.DatabaseRegion,
 		PgVersion:   c.args.PgVersion.Pick(),
 		Provisioner: provisioner,


### PR DESCRIPTION
Use fixed role in all newly created projects. It will make it easier to filter requests from testodrome in proxy logs. 

I guess, we also might need to remove old projects here.